### PR TITLE
feat: loading model once when api starts

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,13 +1,32 @@
+from contextlib import asynccontextmanager
+
+import structlog
 from fastapi import FastAPI
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.api import health, predict
 from app.middleware.logger import structlog_middleware
 from app.utils.logger import setup_structlog
+from app.utils.machine_learning import load_machine_learning_model
+from app.utils.project import get_project_info
 
 setup_structlog()
 
-app = FastAPI(title="churn-prediction", version="0.1.0")
+logger = structlog.get_logger()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    model = load_machine_learning_model("models/model.pth")
+
+    yield {"model": model}
+
+    logger.info("app_shutdown_clearing_machine_learning_model")
+    del model
+
+
+project = get_project_info()
+app = FastAPI(title=project.name, version=project.version, lifespan=lifespan)
 
 app.add_middleware(BaseHTTPMiddleware, dispatch=structlog_middleware)
 

--- a/src/app/utils/machine_learning.py
+++ b/src/app/utils/machine_learning.py
@@ -1,0 +1,39 @@
+import time
+from pathlib import Path
+
+import joblib
+import structlog
+import torch
+
+logger = structlog.get_logger()
+
+
+def load_machine_learning_model(model_path: str):
+    repo_root = Path(__file__).resolve().parents[3]
+    path = Path(model_path)
+    if not path.is_absolute():
+        path = repo_root / path
+
+    if not path.exists() and path.suffix == ".pkl":
+        alt_path = path.with_suffix(".pth")
+        if alt_path.exists():
+            path = alt_path
+
+    logger.info("machine_learning_start_load", {"model_path": str(path)})
+    try:
+        start_time = time.perf_counter()
+        if path.suffix in {".pth", ".pt"}:
+            model = torch.load(path, map_location="cpu")
+        else:
+            model = joblib.load(path)
+        process_time = time.perf_counter() - start_time
+
+        logger.info(
+            "machine_learning_loaded",
+            model_path=str(path),
+            duration_ms=round(process_time * 1000, 2),
+        )
+        return model
+    except Exception:
+        logger.exception("machine_learning_error_load", {"model_path": str(path)})
+        raise

--- a/src/app/utils/project.py
+++ b/src/app/utils/project.py
@@ -1,0 +1,19 @@
+import tomllib
+
+
+class Project:
+    def __init__(self, name: str, version: str) -> None:
+        self.name = name
+        self.version = version
+
+
+def get_project_info() -> Project:
+    with open("pyproject.toml", "rb") as f:
+        data = tomllib.load(f)
+
+    project_info = data.get("project", {})
+
+    name = project_info.get("name", "churn-prediction")
+    version = project_info.get("version", "0.1.0")
+
+    return Project(name=name, version=version)

--- a/tests/unit/app/test_main.py
+++ b/tests/unit/app/test_main.py
@@ -18,3 +18,19 @@ def test_health_router_is_included():
 def test_predict_router_is_included():
     response = client.post("/predict")
     assert response.status_code == 200
+
+
+def test_lifespan_loads_model(monkeypatch):
+    loaded_model = object()
+    called = {}
+
+    def fake_load_machine_learning_model(path):
+        called["path"] = path
+        return loaded_model
+
+    monkeypatch.setattr("app.main.load_machine_learning_model", fake_load_machine_learning_model)
+
+    with TestClient(app) as lifespan_client:
+        assert called["path"] == "models/model.pth"
+        response = lifespan_client.get("/health")
+        assert response.status_code == 200

--- a/tests/unit/app/utils/test_machine_learning.py
+++ b/tests/unit/app/utils/test_machine_learning.py
@@ -1,0 +1,67 @@
+import joblib
+import pytest
+import torch
+
+from app.utils import machine_learning
+
+
+def _patch_repo_root(monkeypatch, tmp_path):
+    original_resolve = machine_learning.Path.resolve
+    fake_machine_learning_file = tmp_path / "src" / "app" / "utils" / "machine_learning.py"
+
+    def fake_resolve(self):
+        if self.name == "machine_learning.py":
+            return fake_machine_learning_file
+        return original_resolve(self)
+
+    monkeypatch.setattr(machine_learning.Path, "resolve", fake_resolve)
+    return tmp_path
+
+
+def test_load_machine_learning_model_pth_relative(monkeypatch, tmp_path):
+    repo_root = _patch_repo_root(monkeypatch, tmp_path)
+    model_dir = repo_root / "models"
+    model_dir.mkdir(parents=True)
+
+    data = {"test": "abc"}
+    pth_path = model_dir / "test_model.pth"
+    torch.save(data, pth_path)
+
+    loaded = machine_learning.load_machine_learning_model("models/test_model.pth")
+
+    assert loaded == data
+
+
+def test_load_machine_learning_model_pkl_direct(monkeypatch, tmp_path):
+    repo_root = _patch_repo_root(monkeypatch, tmp_path)
+    model_dir = repo_root / "models"
+    model_dir.mkdir(parents=True)
+
+    data = {"test": "abc"}
+    pkl_path = model_dir / "test_model.pkl"
+    joblib.dump(data, pkl_path)
+
+    loaded = machine_learning.load_machine_learning_model("models/test_model.pkl")
+
+    assert loaded == data
+
+
+def test_load_machine_learning_model_pkl_fallback_to_pth(monkeypatch, tmp_path):
+    repo_root = _patch_repo_root(monkeypatch, tmp_path)
+    model_dir = repo_root / "models"
+    model_dir.mkdir(parents=True)
+
+    data = {"test": True}
+    pth_path = model_dir / "fallback_model.pth"
+    torch.save(data, pth_path)
+
+    loaded = machine_learning.load_machine_learning_model("models/fallback_model.pkl")
+
+    assert loaded == data
+
+
+def test_load_machine_learning_model_raises_when_missing(monkeypatch, tmp_path):
+    _patch_repo_root(monkeypatch, tmp_path)
+
+    with pytest.raises(FileNotFoundError):
+        machine_learning.load_machine_learning_model("models/missing_model.pkl")

--- a/tests/unit/app/utils/test_project.py
+++ b/tests/unit/app/utils/test_project.py
@@ -1,0 +1,27 @@
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from app.utils.project import get_project_info
+
+MOCK_TOML_CONTENT = b"""
+[project]
+name = "sample-project"
+version = "2.0.0"
+"""
+
+
+@patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML_CONTENT)
+def test_get_project_info_success(mock_file):
+    project = get_project_info()
+
+    assert project.name == "sample-project"
+    assert project.version == "2.0.0"
+
+    mock_file.assert_called_once_with("pyproject.toml", "rb")
+
+
+@patch("builtins.open", side_effect=FileNotFoundError)
+def test_get_project_info_file_not_found(mock_file):
+    with pytest.raises(FileNotFoundError):
+        get_project_info()


### PR DESCRIPTION
# Summary
This PR aims to create a way to load the model once when the application starts in order to reduce the cold start of the first application. We will evaluate the time between the first request and the others requests to see how much time we are taking and the difference, depending on what we have, we can use a dummy predict just to warm up the model.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes, no API changes)

# Test
make run
make test
make e2e